### PR TITLE
Docs: manage the hide from docs option

### DIFF
--- a/utils/fetchCma.js
+++ b/utils/fetchCma.js
@@ -52,10 +52,9 @@ const normalizeSchema = (resource, resourceSchema) => ({
 });
 
 export default async function buildCmaResources(resource) {
-  const { body: unreferencedSchema } = await tiny.get({
-    url: 'https://site-api.datocms.com/docs/site-api-hyperschema.json',
-    // url: 'http://localhost:8080/docs/site-api-hyperschema.json',
-  });
+  const url = 'https://site-api.datocms.com/docs/site-api-hyperschema.json';
+  // const url = 'http://localhost:3001/docs/site-api-hyperschema.json';
+  const { body: unreferencedSchema } = await tiny.get({ url });
 
   const schema = await parser.dereference(unreferencedSchema);
   const resources = Object.keys(schema.properties);

--- a/utils/schemaExampleFor.js
+++ b/utils/schemaExampleFor.js
@@ -3,7 +3,10 @@ export default function schemaExampleFor(schema, pagination = true) {
     return null;
   }
 
-  if (schema.hasOwnProperty('deprecated')) {
+  if (
+    schema.hasOwnProperty('deprecated') ||
+    schema.hasOwnProperty('hideFromDocs')
+  ) {
     return;
   }
 


### PR DESCRIPTION
Do not show properties marked with the "hideFromDocs" key. 
Refactored the Schema view. Now Deprecated properties are showed at the end of the list. 