### PR TITLE
Add activateParentDepth to ActiveLink

### DIFF
--- a/components/ActiveLink/index.js
+++ b/components/ActiveLink/index.js
@@ -2,14 +2,14 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-export default function ActiveLink({ children, activeClassName, ...props }) {
+export default function ActiveLink({ children, ...props }) {
   const router = useRouter();
   const child = React.Children.only(children);
 
   let className = child.props.className || '';
 
-  if (router.pathname === props.href && activeClassName) {
-    className = `${className} ${activeClassName}`.trim();
+  if (isActive(props, router) && props.activeClassName) {
+    className = `${className} ${props.activeClassName}`.trim();
   }
 
   if (props.href.startsWith('#')) {
@@ -17,4 +17,25 @@ export default function ActiveLink({ children, activeClassName, ...props }) {
   }
 
   return <Link {...props}>{React.cloneElement(child, { className })}</Link>;
+}
+
+function isActive(props, router) {
+  const componentUrl = props.as ? props.as : props.href;
+  const routerUrl = props.as ? router.asPath : router.pathname;
+  const urlTokens = routerUrl.split('/');
+
+  if (
+    props.activateParentDepth &&
+    urlTokens.length > props.activateParentDepth
+  ) {
+    const parentPageIdx = props.activateParentDepth - 1;
+    const componentUrlTokens = componentUrl.split('/');
+
+    return (
+      urlTokens[parentPageIdx] == componentUrlTokens[parentPageIdx] &&
+      props.activeClassName
+    );
+  }
+
+  return props.href === router.asPath && props.activeClassName;
 }

--- a/components/MarketplaceLayout/index.js
+++ b/components/MarketplaceLayout/index.js
@@ -12,7 +12,7 @@ import Hamburger from 'public/icons/regular/bars.svg';
 export default function IntegrationsLayout({ children, preview }) {
   const [visible, setVisible] = useState(false);
   const toggleVisibility = useCallback(() => {
-    setVisible(v => !v);
+    setVisible((v) => !v);
   });
 
   return (
@@ -43,6 +43,7 @@ export default function IntegrationsLayout({ children, preview }) {
                 <ActiveLink
                   activeClassName={s.active}
                   href="/marketplace/starters"
+                  activateParentDepth="3"
                 >
                   <a>
                     <span>Starter projects</span>
@@ -51,6 +52,7 @@ export default function IntegrationsLayout({ children, preview }) {
                 <ActiveLink
                   activeClassName={s.active}
                   href="/marketplace/plugins"
+                  activateParentDepth="3"
                 >
                   <a>
                     <span>Plugins</span>
@@ -59,6 +61,7 @@ export default function IntegrationsLayout({ children, preview }) {
                 <ActiveLink
                   activeClassName={s.active}
                   href="/marketplace/hosting"
+                  activateParentDepth="3"
                 >
                   <a>
                     <span>Hosting</span>
@@ -67,6 +70,7 @@ export default function IntegrationsLayout({ children, preview }) {
                 <ActiveLink
                   activeClassName={s.active}
                   href="/marketplace/enterprise"
+                  activateParentDepth="3"
                 >
                   <a>
                     <span>Enterprise</span>

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -38,7 +38,7 @@ Error.getInitialProps = ({ res, err }) => {
       captureUncaught: true,
       captureUnhandledRejections: true,
     });
-    rollbar.error(err, req, (rollbarError) => {
+    rollbar.error(err, res, (rollbarError) => {
       if (rollbarError) {
         console.error('Rollbar error reporting failed:');
         console.error(rollbarError);


### PR DESCRIPTION
With this prop you can mark links as active also if they are the
parents of a currently open URL.

This is needed in navigations where multiple links should be active.