### PR TITLE
update(next/link): removed unnecessary "as" param

### DIFF
--- a/pages/team/developers/index.js
+++ b/pages/team/developers/index.js
@@ -243,24 +243,21 @@ function Developers({ integrations, preview, page, review }) {
 
       <Numbers title="Why you should use DatoCMS">
         <NumbersBlock
-          href="/customers/[slug]"
-          as="/customers/chillys"
+          href="/customers/chillys"
           title="+134%"
           logo={Chillys}
         >
           Mobile conversion rate
         </NumbersBlock>
         <NumbersBlock
-          href="/customers/[slug]"
-          as="/customers/wonderland"
+          href="/customers/wonderland"
           title="6x"
           logo={Wonderland}
         >
           Faster loading times
         </NumbersBlock>
         <NumbersBlock
-          href="/customers/[slug]"
-          as="/customers/matter-supply"
+          href="/customers/matter-supply"
           title="0,9s"
           logo={MatterSupply}
         >
@@ -309,7 +306,6 @@ function Developers({ integrations, preview, page, review }) {
           <Result
             number="-79%"
             href="/customers/hashicorp"
-            as="/customers/[slug]"
             label={
               <>
                 in <Highlight style="good">operational costs</Highlight>
@@ -322,7 +318,6 @@ function Developers({ integrations, preview, page, review }) {
           <Result
             number="0,9s"
             href="/customers/matter-supply"
-            as="/customers/[slug]"
             label={
               <>
                 in <Highlight style="good">loading times</Highlight>


### PR DESCRIPTION
Since Next 9.5.3 "as" param is not necessary: https://nextjs.org/docs/api-reference/next/link#if-the-route-has-dynamic-segments

Also fixed links in "A technology investment that doubles performace and dev team productivity" section, where "as" and "href" params were switched, which was resulting in not working links.