### PR TITLE
Fix overflowing code block

### DIFF
--- a/components/DeployButtonGenerator/style.module.css
+++ b/components/DeployButtonGenerator/style.module.css
@@ -8,6 +8,7 @@
 }
 .datocmsJsonContainer :global(pre) {
   max-width: 100%;
+  box-sizing: border-box;
 }
 .formField:invalid {
   border-color: var(--accent-color);


### PR DESCRIPTION
It seems that you set `box-sizing: content-box` on `pre` elements in the code snippet component

![Screen Shot 2021-03-16 at 10 53 04 AM](https://user-images.githubusercontent.com/711311/111290033-05519f00-8646-11eb-96d1-6e8de23642fa.png)

therefore this code block was overflowing (due to having some padding) 

![Screen Shot 2021-03-16 at 10 50 48 AM](https://user-images.githubusercontent.com/711311/111289567-9411ec00-8645-11eb-9059-7e20a7e1a2fc.png)
