### PR TITLE
Fix scroll to the top on page change

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pretty-quick --staged
+npx pretty-quick --staged

--- a/components/BaseLayout/global.css
+++ b/components/BaseLayout/global.css
@@ -8,7 +8,6 @@
 html {
   line-height: 1.15;
   -webkit-text-size-adjust: 100%;
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
When clicking a link it doesn't always scroll to the top.
Removing this rule makes it a little less nice, but it works more consistently.