### PR TITLE
Display parameter examples from schema

### DIFF
--- a/components/Cma/Schema/index.js
+++ b/components/Cma/Schema/index.js
@@ -245,7 +245,17 @@ function Relationship({ name, schema, required }) {
               {language === 'old-js' ? humps.camelize(name) : name}
             </span>
             {language === 'http' && <span className={s.prefix}>.data</span>}
-            &nbsp;&nbsp;
+            {!isDefinition && (
+              <>
+                &nbsp;&nbsp;
+                {required ? (
+                  <span className={s.required}>Required</span>
+                ) : (
+                  <span className={s.optional}>Optional</span>
+                )}
+                &nbsp;&nbsp;
+              </>
+            )}
             {['http', 'javascript'].includes(language) ||
             multipleRelationshipsPossible ? (
               <span className={s.types}>
@@ -298,16 +308,6 @@ function Relationship({ name, schema, required }) {
                   );
                 })}
               </span>
-            )}
-            {!isDefinition && (
-              <>
-                &nbsp;&nbsp;
-                {required ? (
-                  <span className={s.required}>Required</span>
-                ) : (
-                  <span className={s.optional}>Optional</span>
-                )}
-              </>
             )}
             {schema.deprecated && (
               <>
@@ -374,8 +374,6 @@ export function JsonSchemaProperty({
               <span className={s.name}>
                 {language === 'old-js' ? humps.camelize(name) : name}
               </span>
-              &nbsp;&nbsp;
-              <Type schema={schema} />
               {schema.deprecated && (
                 <>
                   &nbsp;&nbsp;
@@ -392,6 +390,30 @@ export function JsonSchemaProperty({
                   )}
                 </>
               )}
+              &nbsp;&nbsp;
+              <Type schema={schema} />
+              {
+                // The plural "examples" will array.join these: [true,false] -> "true,false"
+                schema.examples && schema.examples.length ? (
+                  <>
+                    &nbsp;&nbsp;<span className={s.example}>Examples: </span>
+                    {schema.examples.map((ex, i) => [
+                      i > 0 && ', ',
+                      <span className={s.type} key={i}>
+                        {JSON.stringify(ex)}
+                      </span>,
+                    ])}
+                  </>
+                ) : // The singular example will just JSON stringify: [true, false] -> [true, false]
+                schema.example ? (
+                  <>
+                    &nbsp;&nbsp;<span className={s.example}>Example: </span>
+                    <span className={s.type}>
+                      {JSON.stringify(schema.example)}
+                    </span>
+                  </>
+                ) : null
+              }
             </div>
           )}
           {schema.description && (


### PR DESCRIPTION
In preparation for the documentation updates, I noticed that the JSON schema currently has some [parameter examples](https://github.com/datocms/api/blob/master/schemas/site_api/item.json#L1031-L1035), e.g.:

```json
"nested": {
            "description": "For Modular Content fields and Structured Text fields. If set, returns full payload for nested blocks instead of IDs",
            "example": true,
            "type": ["boolean"]
},
```
But those were not getting rendered on the website.

## Before
![image](https://github.com/datocms/new-website/assets/11964962/d11482fc-287d-41d0-8c5f-4555cdcd9be3)


## After
![image](https://github.com/datocms/new-website/assets/11964962/9eff1097-6efc-4171-bece-29057c1ca64c)

# Example (singular) vs Examples (plural)

I also added a new ["examples" (plural) parser](https://github.com/datocms/new-website/pull/40/files#diff-59ac422e4d02b9208d1c51b8ccc3bfeed0dd19575f90e182d65404a6d5ff81e0R397-R406) that will join array elements instead of `JSON.stringify()`:

![image](https://github.com/datocms/new-website/assets/11964962/c6b07c12-da23-48d3-a0e7-588f3dab9067)

From the JSON:
```json
                  "content_in_locales": {
                    "type": "array",
                    "description": "Array of [valid locale codes in this project](https://www.datocms.com/product-updates/get-locales-list-from-graphql) to publish. \n\nThis is required if `non_localized_content` is provided. WARNING: If this array contains invalid locales, nulls, or empty strings, ALL locales of this record will be published. This behavior maintains backward compatibility with previous client versions.",
                    "example": ["en", "it"],
                    "items": { "type": "string"}
                  },
                  "non_localized_content": {
                    "type": "boolean",
                    "description": "Whether non-localized fields of this record will also be published. This is required if `content_in_locales` is provided.",
                    "examples": [true, false]
                  }
```

This can also be used to render multiple array examples:
![image](https://github.com/datocms/new-website/assets/11964962/8f33e7fa-2b2e-4fe3-8eb1-4b03d1283f6b)

From:
```json
                  "content_in_locales": {
                    "type": "array",
                    "description": "Array of [valid locale codes in this project](https://www.datocms.com/product-updates/get-locales-list-from-graphql) to publish. \n\nThis is required if `non_localized_content` is provided. To publish an entire record (all locales), do not include either this parameter or `non_localized_content` (see example). \n\n WARNING: If this array contains invalid locales, nulls, or empty strings, ALL locales of this record will be published. This behavior is necessary for backward compatibility.\n\n",
                    "examples": [["en"], ["en", "it"]],
                    "items": { "type": "string"}
                  },
```