### PR TITLE
(DO NOT MERGE YET) Show `properties.description` if it exists

### DIFF
--- a/components/Cma/Schema/index.js
+++ b/components/Cma/Schema/index.js
@@ -551,6 +551,9 @@ export function Schema({ title, schema, showId }) {
               <div className={s.description}>
                 Must be exactly{' '}
                 <code>&quot;{schema.properties.type.example}&quot;</code>
+                {schema.properties.type.description && (
+                  <p>{schema.properties.type.description}</p>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
**WARNING: Please do NOT merge this until https://github.com/datocms/api/pull/361 is deployed**

-----------

In conjunction with https://github.com/datocms/api/pull/361, this will allow us to show useful descriptions for parameter `properties`, not just `attributes`.

From:
![image](https://github.com/datocms/new-website/assets/11964962/b64f3f4d-a9f1-4644-81ae-d2736a8b8fb0)

We can show:
![image](https://github.com/datocms/new-website/assets/11964962/db96d249-1a6c-4269-88c4-6718736b3824)

-------------

But this should NOT be merged until the [other PR](https://github.com/datocms/api/pull/361) is merged first, or we'll end up with a bunch of unhelpful generic descriptions:

![image](https://github.com/datocms/new-website/assets/11964962/c61a854e-3342-4aaa-9a4e-ffc6ae35edfa)
