### PR TITLE
Also add request and return descriptions

### DIFF
--- a/components/Cma/HttpExample/index.js
+++ b/components/Cma/HttpExample/index.js
@@ -123,11 +123,17 @@ function renderExample(example, resource) {
       title={title}
       description={description}
       chunks={[
-        { title: 'HTTP Request:', code: requestCode, language: 'http' },
+        {
+          title: 'HTTP Request',
+          code: requestCode,
+          language: 'http',
+          description: request?.description ?? '',
+        },
         responseCode && {
-          title: 'HTTP Response:',
+          title: 'HTTP Response',
           code: responseCode,
           language: 'http',
+          description: response?.description ?? '',
         },
       ].filter((x) => !!x)}
     />

--- a/components/Cma/RequestResponse/index.js
+++ b/components/Cma/RequestResponse/index.js
@@ -45,6 +45,9 @@ const RequestResponse = ({ title, description, chunks }) => (
     {chunks.map((chunk) => (
       <div className={s.chunk} key={chunk.title}>
         <div className={s.chunkTitle}>{chunk.title}</div>
+        {chunk.description && (
+          <div className={s.description}>{chunk.description}</div>
+        )}
         <Prism code={chunk.code} language={chunk.language} />
       </div>
     ))}

--- a/components/Cma/RequestResponse/style.module.css
+++ b/components/Cma/RequestResponse/style.module.css
@@ -22,13 +22,18 @@
     max-height: 400px;
     overflow: auto;
   }
+
+  .description {
+    margin-bottom: 0.5em;
+    font-size: 15px;
+    font-family: var(--font-sans);
+  }
 }
 
 .chunkTitle {
   font-family: var(--font-sans);
   margin-bottom: 15px;
-  color: var(--light-body-color);
-  font-size: 0.9em;
+  font-weight: bold;
 }
 
 .description {


### PR DESCRIPTION
Similar to https://github.com/datocms/new-website/pull/44, but this one shows optional descriptions for example requests and responses.

## Before
![image](https://github.com/datocms/new-website/assets/11964962/8d077e5f-0ad1-42a0-8f37-6aacd0a8b372)

## After
![image](https://github.com/datocms/new-website/assets/11964962/e9a2c5b8-0244-401f-aedd-d75a63ff9266)

## Example schema
This is what an updated `site_api/item.json` in the API repo would look like:
```json
      "examples": {
        "http": [
          {
            "title": "Publish the entire record",
            "description": {
              "$externalStringRef": "./item_publish/http/entire-record/description.md"
            },
            "request": {
              "method": "PUT",
              "description": "(No request body)",
              "url": "https://site-api.datocms.com/items/:item_id/publish",
              "body": ""
            },
            "response": {
              "statusCode": 200,
              "statusText": "OK",
              "description": "Updated item:",
              "body": {
                "$externalStringRef": "./item_publish/http/entire-record/response.json"
              }
            }
          }
        ]
      },
```

`request` and `response` can have optional `description` strings now. If they're not provided, it stays as before (with slightly tweaked styling):

![image](https://github.com/datocms/new-website/assets/11964962/9b0b2f16-9ba3-4dc7-8c77-cf5741aee7db)
