### PR TITLE
[Docs] Fix CURL & fetch() descriptions to show requests and not responses

### DIFF
--- a/components/Cma/HttpExamples/index.js
+++ b/components/Cma/HttpExamples/index.js
@@ -201,13 +201,13 @@ export function HttpExample({ example, link, startExpanded }) {
       title: 'CURL Request',
       code: generateCurlSnippet(request),
       language: 'bash',
-      description: example.response?.description ?? '',
+      description: example.request?.description ?? '',
     },
     {
       title: 'fetch() Request',
       code: buildFetchCommand(request),
       language: 'js',
-      description: example.response?.description ?? '',
+      description: example.request?.description ?? '',
     },
   ];
 


### PR DESCRIPTION
The CURL and fetch() request inside examples were accidentally showing the _response_ description instead of the _request_ one.

## Before
![image](https://github.com/datocms/new-website/assets/11964962/632b5589-82f4-44a1-bec1-21f48e988eea)

## After
![image](https://github.com/datocms/new-website/assets/11964962/74ad34df-513a-43e4-a6f8-d18a27fe01f9)
