### PR TITLE
[Docs] Allow basic Markdown in chunk descriptions

### DIFF
--- a/components/Cma/RequestResponse/index.js
+++ b/components/Cma/RequestResponse/index.js
@@ -86,7 +86,9 @@ const RequestResponse = ({ title, description, chunks, startExpanded }) => {
 
           <div className={s.chunk}>
             {activeChunk.description && (
-              <div className={s.description}>{activeChunk.description}</div>
+              <ReactMarkdown className={s.description} remarkPlugins={[gfm]}>
+                {activeChunk.description}
+              </ReactMarkdown>
             )}
             {activeChunk.code && (
               <Prism code={activeChunk.code} language={activeChunk.language} />


### PR DESCRIPTION
This is a dependency for a bigger docs update project, https://github.com/datocms/api/pull/392

This is a simple patch that allows rendering Markdown in request/response "chunk" descriptions.

## item.json from the API
```json
 "response": {
                "description": "Note that while `meta.total_count` is still 6 (the total number of records in this example project), the length of `data[]` will be only 2, since that's the limit we requested.",
                "body": {
                  "$externalStringRef": "./item_instances/examples/paginated/response.json"
                }
              }
```

## Before
![image](https://github.com/datocms/new-website/assets/11964962/0b72bcce-8656-4a67-a76e-8007c99fae66)

## After
![image](https://github.com/datocms/new-website/assets/11964962/74ded3c8-113b-4f10-a531-2d2193e1b6ef)
