### PR TITLE
[Docs] Colorize http headers in example requests

### DIFF
--- a/components/Prism/index.js
+++ b/components/Prism/index.js
@@ -6,26 +6,19 @@ import s from './style.module.css';
 import { range } from 'range';
 import { useMemo } from 'react';
 
-const modifiedStyles = [
-  {
-    types: ['comment'],
-    style: {
-      color: '#98c6e7',
-      fontStyle: 'italic',
-    },
-  },
-  {
-    types: ['header-name'],
-    languages: ['http'],
-    style: {
-      color: 'rgb(130, 170, 255)',
-    },
-  },
-];
-
 const modifiedTheme = {
   ...theme,
-  styles: [...theme.styles, ...modifiedStyles],
+  styles: theme.styles.map((style) =>
+    style.types.includes('comment')
+      ? {
+          types: ['comment'],
+          style: {
+            color: '#98c6e7',
+            fontStyle: 'italic',
+          },
+        }
+      : style,
+  ),
 };
 
 const Prism = ({ code, language, showLineNumbers, highlightLines = [] }) => {

--- a/components/Prism/index.js
+++ b/components/Prism/index.js
@@ -6,19 +6,26 @@ import s from './style.module.css';
 import { range } from 'range';
 import { useMemo } from 'react';
 
+const modifiedStyles = [
+  {
+    types: ['comment'],
+    style: {
+      color: '#98c6e7',
+      fontStyle: 'italic',
+    },
+  },
+  {
+    types: ['header-name'],
+    languages: ['http'],
+    style: {
+      color: 'rgb(130, 170, 255)',
+    },
+  },
+];
+
 const modifiedTheme = {
   ...theme,
-  styles: theme.styles.map((style) =>
-    style.types.includes('comment')
-      ? {
-          types: ['comment'],
-          style: {
-            color: '#98c6e7',
-            fontStyle: 'italic',
-          },
-        }
-      : style,
-  ),
+  styles: [...theme.styles, ...modifiedStyles],
 };
 
 const Prism = ({ code, language, showLineNumbers, highlightLines = [] }) => {

--- a/pages/docs/content-management-api/resources/[resource]/[endpoint].js
+++ b/pages/docs/content-management-api/resources/[resource]/[endpoint].js
@@ -209,7 +209,9 @@ export default function DocPage({
                       {description}
                     </DocDescription>
                   )}
-                  {link.hrefSchema && <HrefSchema schema={link.hrefSchema} />}
+                  {link.hrefSchema && (
+                    <HrefSchema schema={link.hrefSchema} language={language} />
+                  )}
                   {link.schema && (
                     <Schema
                       title="Body Parameters"

--- a/utils/stripQuotes.js
+++ b/utils/stripQuotes.js
@@ -1,0 +1,14 @@
+// This removes beginning and quotes from a string, like "example" becomes example
+// This is mainly used for query string examples in HTTP calls, because adding a quote mark there will break the URL
+
+export const stripQuotes = (inputString) => {
+  if (
+    inputString &&
+    typeof inputString === 'string' &&
+    inputString.startsWith('"') &&
+    inputString.endsWith('"')
+  ) {
+    return inputString.substring(1, inputString.length - 1);
+  }
+  return inputString;
+};


### PR DESCRIPTION
Small change to make HTTP requests more readable.

## Before
![image](https://github.com/datocms/new-website/assets/11964962/c76fab58-0153-429c-8615-7ee745f60f59)


## After
![image](https://github.com/datocms/new-website/assets/11964962/c19e0e5e-6533-4a96-a847-1e787b075941)
