### PR TITLE
Allow Discourse searches to fail gracefully without breaking doc sear…

### DIFF
--- a/components/DocSearch/index.js
+++ b/components/DocSearch/index.js
@@ -13,25 +13,30 @@ const client = new DatoCmsSearch('d46fe8134ea916b42af4eaa0d06109');
 const fetchCommunity = async (query) => {
   const endpoint = 'https://community.datocms.com/search/query.json';
 
-  const { topics, posts } = await wretch(
-    `${endpoint}?include_blurbs=true&term=${encodeURIComponent(query)}`,
-  )
-    .get()
-    .json();
+  try {
+    const { topics, posts } = await wretch(
+      `${endpoint}?include_blurbs=true&term=${encodeURIComponent(query)}`,
+    )
+      .get()
+      .json();
 
-  if (!posts) {
+    if (!posts) {
+      return [];
+    }
+
+    return posts.map((post) => {
+      const topic = topics.find((t) => t.id === post.topic_id);
+      return {
+        title: highlighter(query || '', topic.title),
+        body: highlighter(query || '', post.blurb),
+        url: `https://community.datocms.com/t/${topic.slug}/${topic.id}`,
+        community: true,
+      };
+    });
+  } catch (error) {
+    console.error(`Error seaching the DatoCMS forum: ${error}`);
     return [];
   }
-
-  return posts.map((post) => {
-    const topic = topics.find((t) => t.id === post.topic_id);
-    return {
-      title: highlighter(query || '', topic.title),
-      body: highlighter(query || '', post.blurb),
-      url: `https://community.datocms.com/t/${topic.slug}/${topic.id}`,
-      community: true,
-    };
-  });
 };
 
 const search = async (query) => {


### PR DESCRIPTION
See https://3.basecamp.com/5656352/buckets/33592869/card_tables/cards/7286405062 for details

There is currently a CORS error from the forum that's blocking our documentation search completely. I don't have the ability to fix it on the Discourse side (requires an env var change and restart, I think), but this at least lets the search work again

## Before
(Broken)
![image](https://github.com/datocms/new-website/assets/11964962/113ecba4-8806-44a4-bc91-4c22c081f508)


## After
(No posts from community, but at least search works)
![image](https://github.com/datocms/new-website/assets/11964962/81d10804-f3ee-4fe7-adf3-37e7aa5a7734)
