### PR TITLE
Feat/tech partners

### DIFF
--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -96,6 +96,12 @@ export default function Footer({ noCta }) {
                 </div>
 
                 <div className={s.monoLink}>
+                  <Link href="/support">
+                    <a>Support</a>
+                  </Link>
+                </div>
+
+                <div className={s.monoLink}>
                   <Link href="/enterprise-headless-cms">
                     <a>DatoCMS for Enterprise</a>
                   </Link>
@@ -202,8 +208,8 @@ export default function Footer({ noCta }) {
                       </Link>
                     </div>
                     <div className={s.groupLink}>
-                      <Link href="/support">
-                        <a>Support</a>
+                      <Link href="/blog">
+                        <a>Blog</a>
                       </Link>
                     </div>
                     <div className={s.groupLink}>
@@ -233,39 +239,7 @@ export default function Footer({ noCta }) {
                     </div>
                   </div>
                 </div>
-                <div className={s.group}>
-                  <div className={s.groupTitle}>Social</div>
-                  <div className={s.groupLinks}>
-                    <div className={s.groupLink}>
-                      <Link href="/blog">
-                        <a>Blog</a>
-                      </Link>
-                    </div>
-                    <div className={s.groupLink}>
-                      <a
-                        href="https://community.datocms.com"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Community forum
-                      </a>
-                    </div>
-                    <div className={s.groupLink}>
-                      <Link href="/slack">
-                        <a>Slack channel</a>
-                      </Link>
-                    </div>
-                    <div className={s.groupLink}>
-                      <a
-                        href="https://www.twitter.com/datocms"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Twitter
-                      </a>
-                    </div>
-                  </div>
-                </div>
+                
               </div>
               <div className={s.col}>
                 <div className={s.group}>
@@ -346,6 +320,21 @@ export default function Footer({ noCta }) {
                     <div className={s.groupLink}>
                       <Link href="/security">
                         <a>Security</a>
+                      </Link>
+                    </div>
+                    <div className={s.groupLink}>
+                      <Link href="https://community.datocms.com">
+                        <a>Community Forum</a>
+                      </Link>
+                    </div>
+                    <div className={s.groupLink}>
+                      <Link href="/slack">
+                        <a>Slack Channel</a>
+                      </Link>
+                    </div>
+                    <div className={s.groupLink}>
+                      <Link href="https://twitter.com/datocms">
+                        <a>Twitter</a>
                       </Link>
                     </div>
                   </div>

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -192,6 +192,11 @@ export default function Footer({ noCta }) {
                       </Link>
                     </div>
                     <div className={s.groupLink}>
+                      <Link href="/tech-partners">
+                        <a>Technology partners</a>
+                      </Link>
+                    </div>
+                    <div className={s.groupLink}>
                       <Link href="/partners">
                         <a>Solution partners</a>
                       </Link>

--- a/components/Navbar/index.jsx
+++ b/components/Navbar/index.jsx
@@ -462,11 +462,41 @@ export default function Navbar() {
                 </Pane>
               </div>
 
-              <Link href="/partners">
-                <a className={s.entry}>
+              <div className={s.group}>
+                <div className={s.groupTitle}>
                   <span>Partners</span>
-                </a>
-              </Link>
+                </div>
+
+                <Pane>
+                  <div className={s.cols}>
+                    <div className={s.cols}>
+                      <div className={s.section}>
+                        <div className={s.grid1}>
+                          <TitleDesc
+                            href="/partners"
+                            title="Solution Partners"
+                            description="Find the perfect agency partner for your projects"
+                          />
+                          <TitleDesc
+                            href="/tech-partners"
+                            title="Technology Partners"
+                            description="Explore our partner APIs to supercharge your projects"
+                          />
+                        </div>
+                      </div>
+                      <div className={s.section}>
+                        <div className={s.grid1}>
+                          <TitleDesc
+                            href="/partner-program"
+                            title="Our Partner Program"
+                            description="If you're an agency, join 80+ partners from 45+ countries in implementing DatoCMS for their clients worldwide"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </Pane>
+              </div>
             </div>
 
             <div className={s.actions}>

--- a/components/Navbar/index.jsx
+++ b/components/Navbar/index.jsx
@@ -489,7 +489,7 @@ export default function Navbar() {
                           <TitleDesc
                             href="/partner-program"
                             title="Our Partner Program"
-                            description="If you're an agency, join 80+ partners from 45+ countries in implementing DatoCMS for their clients worldwide"
+                            description="Find out what benefits you and your clients enjoy as a DatoCMS Agency partner!"
                           />
                         </div>
                       </div>

--- a/pages/tech-partners/[slug]/index.jsx
+++ b/pages/tech-partners/[slug]/index.jsx
@@ -115,7 +115,7 @@ export default function TechPartnerPage({ preview, subscription }) {
     <Layout preview={preview} noCta>
       <Head>
         {renderMetaTags(techPartner.seo)}
-        <title>{techPartner.name} | DatoCMS Technology Partners</title>
+        <title>{techPartner.name} | DatoCMS Ecosystem Partners</title>
         <meta
           name="description"
           content={toPlainText(techPartner.shortDescription)}

--- a/pages/tech-partners/[slug]/index.jsx
+++ b/pages/tech-partners/[slug]/index.jsx
@@ -1,0 +1,222 @@
+import Button from 'components/Button';
+import Head from 'components/Head';
+import InterstitialTitle from 'components/InterstitialTitle';
+import Layout from 'components/Layout';
+import LazyImage from 'components/LazyImage';
+import SidebarPane from 'components/SidebarPane';
+import Space from 'components/Space';
+import StickySidebar from 'components/StickySidebar';
+import Wrapper from 'components/Wrapper';
+import { render as toPlainText } from 'datocms-structured-text-to-plain-text';
+import { isBlockquote } from 'datocms-structured-text-utils';
+import {
+  gqlStaticPaths,
+  handleErrors,
+  request,
+  seoMetaTagsFields,
+} from 'lib/datocms';
+import EnvelopeIcon from 'public/icons/regular/envelope.svg';
+import DescriptionIcon from 'public/icons/regular/info.svg';
+import LaptopIcon from 'public/icons/regular/laptop-code.svg';
+import BrowserIcon from 'public/icons/regular/link.svg';
+import MapPinIcon from 'public/icons/regular/map-marker.svg';
+import MarkerIcon from 'public/icons/regular/marker.svg';
+import { StructuredText, renderMetaTags, renderRule } from 'react-datocms';
+import { useQuerySubscription } from 'utils/useQuerySubscription';
+import s from './style.module.css';
+
+export const getStaticPaths = gqlStaticPaths(
+  `
+    query {
+      techPartners: allTechPartners(first: 100, orderBy: name_ASC) {
+        slug
+      }
+    }
+  `,
+  'slug',
+  ({ techPartners }) => techPartners.map((p) => p.slug),
+);
+
+export const getStaticProps = handleErrors(
+  async ({ params: { slug }, preview }) => {
+    const gqlRequest = {
+      query: /* GraphQL */ `
+        query TechPartnerQuery($slug: String!) {
+          techPartner(filter: { slug: { eq: $slug } }) {
+            seo: _seoMetaTags {
+              ...seoMetaTagsFields
+            }
+            id
+            slug
+            name
+            shortDescription {
+              value
+            }
+            logo {
+              url
+            }
+            description {
+              value
+            }
+            publicContactEmail
+            websiteUrl
+            areasOfExpertise {
+              name
+              slug
+            }
+            technologies {
+              name
+              slug
+            }
+            locations {
+              name
+              emoji
+              continent {
+                name
+              }
+            }
+          }
+        }
+        ${seoMetaTagsFields}
+      `,
+      variables: { slug },
+      preview: preview || false,
+    };
+
+    const { data } = await request(gqlRequest);
+
+    if (!data.techPartner) {
+      return { notFound: true };
+    }
+
+    return {
+      revalidate: 60 * 10,
+      props: {
+        preview: preview || false,
+        subscription: preview
+          ? {
+              ...gqlRequest,
+              token: process.env.NEXT_PUBLIC_DATOCMS_READONLY_TOKEN,
+              enabled: true,
+              initialData: data,
+            }
+          : { enabled: false, initialData: data },
+      },
+    };
+  },
+);
+
+export default function TechPartnerPage({ preview, subscription }) {
+  const {
+    data: { techPartner },
+  } = useQuerySubscription(subscription);
+
+  return (
+    <Layout preview={preview} noCta>
+      <Head>
+        {renderMetaTags(techPartner.seo)}
+        <title>{techPartner.name} | DatoCMS Technology Partners</title>
+        <meta
+          name="description"
+          content={toPlainText(techPartner.shortDescription)}
+        />
+      </Head>
+      <InterstitialTitle
+        mainTitleOfPage
+        style="two"
+        kicker={<>DatoCMS Technology Partner</>}
+        bigSubtitle
+        subtitle={<StructuredText data={techPartner.shortDescription} />}
+      >
+        <LazyImage
+          className={s.logo}
+          alt={`${techPartner.name} logo`}
+          src={techPartner.logo.url}
+        />
+      </InterstitialTitle>
+      <Wrapper>
+        <Space top={1}>
+          <StickySidebar
+            sidebar={
+              <>
+                <SidebarPane
+                  icon={<MapPinIcon />}
+                  title={
+                    techPartner.locations.length > 1 ? 'Locations' : 'Location'
+                  }
+                >
+                  <ul className={s.list}>
+                    {techPartner.locations.map((location) => (
+                      <li key={location.name}>
+                        {location.emoji} {location.name}
+                      </li>
+                    ))}
+                  </ul>
+                </SidebarPane>
+                <SidebarPane icon={<MarkerIcon />} title="Services offered">
+                  <ul className={s.list}>
+                    {techPartner.areasOfExpertise.map((area) => (
+                      <li key={area.slug}>{area.name}</li>
+                    ))}
+                  </ul>
+                </SidebarPane>
+                <SidebarPane icon={<LaptopIcon />} title="Covered technologies">
+                  <ul className={s.list}>
+                    {techPartner.technologies.map((tech) => (
+                      <li key={tech.slug}>{tech.name}</li>
+                    ))}
+                  </ul>
+                </SidebarPane>
+              </>
+            }
+          >
+            <SidebarPane
+              separateMoreFromContent
+              icon={<DescriptionIcon />}
+              title={`About ${techPartner.name}`}
+            >
+              <div className={s.description}>
+                <StructuredText
+                  data={techPartner.description}
+                  customRules={[
+                    renderRule(isBlockquote, ({ node, children, key }) => {
+                      return (
+                        <div key={key} className={s.quote}>
+                          <div className={s.quoteQuote}>{children}</div>
+                          {node.attribution && (
+                            <div className={s.quoteAuthor}>
+                              {node.attribution}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    }),
+                  ]}
+                />
+              </div>
+              <div className={s.action}>
+                <div className={s.actionButton}>
+                  <Button as="a" href={techPartner.websiteUrl} target="_blank">
+                    <BrowserIcon /> Visit website
+                  </Button>
+                </div>
+                {techPartner.publicContactEmail && (
+                  <div className={s.actionButton}>
+                    <Button
+                      as="a"
+                      s="invert"
+                      href={`mailto:${techPartner.publicContactEmail}`}
+                      target="_blank"
+                    >
+                      <EnvelopeIcon /> Contact {techPartner.name}
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </SidebarPane>
+          </StickySidebar>
+        </Space>
+      </Wrapper>
+    </Layout>
+  );
+}

--- a/pages/tech-partners/[slug]/style.module.css
+++ b/pages/tech-partners/[slug]/style.module.css
@@ -1,0 +1,119 @@
+.action {
+  margin-top: rfs(40px);
+  margin-bottom: rfs(40px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.actionButton {
+  margin-right: 5px;
+
+  @media (width <= 500px) {
+    display: none;
+
+    &:first-child {
+      display: block;
+    }
+  }
+}
+
+.description {
+  max-width: 600px;
+  a {
+    color: var(--accent-color);
+  }
+}
+
+.logo {
+  height: rfs(150px);
+}
+
+.list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  line-height: 1.4;
+
+  li {
+    margin: 0;
+  }
+}
+
+.techLogo {
+  height: 25px;
+  margin-top: 20px;
+}
+
+.projectsGrid {
+  display: grid;
+  grid-gap: 30px;
+  grid-template-columns: 1fr;
+
+  @media (width > 450px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.pluginsGrid {
+  display: grid;
+  grid-gap: 30px;
+  grid-template-columns: 1fr;
+
+  @media (width > 450px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  @media (width > 850px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.quote {
+  text-align: left;
+  padding-top: rfs(30px);
+  position: relative;
+
+  &:before {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 40px;
+    font-family: var(--font-serif);
+    content: '\201C';
+    color: var(--accent-color);
+    font-size: rfs(100px);
+    line-height: 0.3;
+  }
+}
+
+.quoteQuote {
+  line-height: 1.2;
+  margin-left: rfs(50px);
+  font-family: var(--font-serif);
+  color: #333;
+
+  p,
+  ul,
+  ol {
+    margin: 0 0 rfs(20px);
+  }
+
+  strong {
+    background-image: linear-gradient(120deg, #f4cf58 0%, #f4cf58 100%);
+    background-repeat: no-repeat;
+    background-size: 100% 0.5em;
+    background-position: 0 88%;
+    font-weight: 600;
+  }
+}
+
+.quoteAuthor {
+  margin-left: rfs(50px);
+  font-style: italic;
+  color: var(--light-body-color);
+
+  &:before {
+    content: '—';
+    padding-right: 10px;
+  }
+}

--- a/pages/tech-partners/[slug]/style.module.css
+++ b/pages/tech-partners/[slug]/style.module.css
@@ -47,7 +47,7 @@
 
 .projectsGrid {
   display: grid;
-  grid-gap: 30px;
+  gap: 30px;
   grid-template-columns: 1fr;
 
   @media (width > 450px) {
@@ -57,7 +57,7 @@
 
 .pluginsGrid {
   display: grid;
-  grid-gap: 30px;
+  gap: 30px;
   grid-template-columns: 1fr;
 
   @media (width > 450px) {

--- a/pages/tech-partners/index.jsx
+++ b/pages/tech-partners/index.jsx
@@ -1,0 +1,344 @@
+import classNames from 'classnames';
+import Head from 'components/Head';
+import Hero from 'components/Hero';
+import Highlight from 'components/Highlight';
+import Layout from 'components/Layout';
+import { Announce } from 'components/PluginToolkit';
+import Space from 'components/Space';
+import Wrapper from 'components/Wrapper';
+import { render as toPlainText } from 'datocms-structured-text-to-plain-text';
+import { gqlStaticPropsWithSubscription } from 'lib/datocms';
+import { uniq } from 'lodash-es';
+import sortBy from 'lodash-es/sortBy';
+import Link from 'next/link';
+import React, { useState } from 'react';
+import ReactSelect from 'react-select';
+import { useQuerySubscription } from 'utils/useQuerySubscription';
+import s from './style.module.css';
+
+export const getStaticProps = gqlStaticPropsWithSubscription(
+  /* GraphQL */ `
+  {
+    techPartnersPage {
+      highlightedPartners {
+        ...techPartner
+      }
+    }
+        posts1: allTechPartners(first: 100) {
+          ...techPartner
+        }
+        posts2: allTechPartners(skip: 100, first: 100) {
+          ...techPartner
+        }
+        posts3: allTechPartners(skip: 200, first: 100) {
+          ...techPartner
+        }
+  }
+  
+  fragment techPartner on TechPartnerRecord {
+    name
+    slug
+    logo {
+      url
+    }
+    shortDescription {
+      value
+    }
+    areasOfExpertise {
+      name
+    }
+    technologies {
+      name
+    }
+    locations {
+      emoji
+      name
+      code
+      continent {
+        name
+      }
+    }
+  }
+`,
+  {
+    requiredKeys: ['posts1'],
+  },
+);
+
+const styles = [s.azureLogo, s.pinkLogo, s.blueLogo, s.greenLogo, s.yellowLogo];
+
+const toOption = (entry) => ({
+  value: entry[0],
+  label: entry[0],
+});
+const byCount = (entryA, entryB) => {
+  if (entryA[1] !== entryB[1]) {
+    return entryB[1] - entryA[1];
+  }
+
+  return entryA[0].localeCompare(entryB[0]);
+};
+
+function calculateCounters(agencies, continent, country) {
+  const allTechnologies = {};
+  const allAreaOfExpertise = {};
+  const allCountries = {};
+  const allContinents = {};
+
+  for (const p of agencies) {
+    for (const t of p.technologies) {
+      allTechnologies[t.name] = (allTechnologies[t.name] || 0) + 1;
+    }
+    for (const t of p.areasOfExpertise) {
+      allAreaOfExpertise[t.name] = (allAreaOfExpertise[t.name] || 0) + 1;
+    }
+    for (const t of p.locations) {
+      if (!continent || t.continent.name === continent)
+        allCountries[`${t.emoji} ${t.name}`] =
+          (allCountries[`${t.emoji} ${t.name}`] || 0) + 1;
+    }
+    for (const continentName of uniq(
+      p.locations.map((t) => t.continent.name),
+    )) {
+      allContinents[continentName] = (allContinents[continentName] || 0) + 1;
+    }
+  }
+
+  return {
+    technologies: allTechnologies,
+    areaOfExpertise: allAreaOfExpertise,
+    countries: allCountries,
+    continents: allContinents,
+  };
+}
+
+export default function TechPartners({ subscription, preview }) {
+  const {
+    data: { posts1, posts2, posts3, techPartnersPage },
+  } = useQuerySubscription(subscription);
+
+  const posts = [...posts1, ...posts2, ...posts3];
+
+  const countBySlug = posts.reduce((acc, post) => {
+    acc[post.slug] = post._allReferencingTechPartners;
+    return acc;
+  }, {});
+
+  const highlightedSlugs = techPartnersPage.highlightedPartners.map(
+    (p) => p.slug,
+  );
+
+  const ordered = [
+    ...techPartnersPage.highlightedPartners,
+    ...sortBy(
+      posts.filter((p) => !highlightedSlugs.includes(p.slug)),
+      [(x) => -(countBySlug[x.slug] || 0), 'slug'],
+    ),
+  ];
+
+  const [technologyFilter, setTechnologyFilter] = useState(null);
+  const [areaOfExpertiseFilter, setAreaOfExpertiseFilter] = useState(null);
+  const [countryFilter, setCountryFilter] = useState(null);
+  const [continentFilter, setContinentFilter] = useState(null);
+
+  const filtered = ordered.filter((p) => {
+    if (
+      technologyFilter &&
+      !p.technologies.some((t) => t.name === technologyFilter)
+    ) {
+      return false;
+    }
+    if (
+      areaOfExpertiseFilter &&
+      !p.areasOfExpertise.some((t) => t.name === areaOfExpertiseFilter)
+    ) {
+      return false;
+    }
+    if (
+      countryFilter &&
+      !p.locations.some((t) => `${t.emoji} ${t.name}` === countryFilter)
+    ) {
+      return false;
+    }
+    if (
+      continentFilter &&
+      !p.locations.some((t) => t.continent.name === continentFilter)
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
+  const filteredCounters = calculateCounters(filtered, continentFilter);
+  const noFilterCounters = calculateCounters(ordered, continentFilter);
+
+  const someFilters =
+    continentFilter ||
+    countryFilter ||
+    technologyFilter ||
+    areaOfExpertiseFilter;
+
+  const continentOptions = Object.entries(filteredCounters.continents)
+    .sort(byCount)
+    .map(toOption);
+
+  const countryOptions = Object.entries(filteredCounters.countries)
+    .sort(byCount)
+    .map(toOption);
+
+  const technologyOptions = Object.entries(filteredCounters.technologies)
+    .sort(byCount)
+    .map(toOption);
+
+  const areaOfExpertiseOptions = Object.entries(
+    filteredCounters.areaOfExpertise,
+  )
+    .sort(byCount)
+    .map(toOption);
+
+  return (
+    <Layout preview={preview}>
+      <Head>
+        <title>DatoCMS Technology Partners</title>
+      </Head>
+      <Wrapper>
+        <Hero
+          kicker="Ecosystem Partners"
+          title={
+            <>
+              Find the perfect Tech Partner to supercharge{' '}
+              <Highlight>your DatoCMS projects</Highlight>
+            </>
+          }
+          subtitle={
+            <>
+              DatoCMS partners with leading technology providers and APIs to
+              ensure your projects are getting the best possible treatment.
+            </>
+          }
+        />
+
+        <Space bottom={1}>
+          <Announce href="/partner-program" center>
+            <strong>Want to become a DatoCMS Partner?</strong> Learn more about
+            our Partner Program and its benefits!
+          </Announce>
+        </Space>
+
+        {/* <div className={s.filterGrid}>
+          <div className={s.filter}>
+            <div className={s.filterLabel}>Filter by Continent</div>
+            <ReactSelect
+              isClearable
+              formatOptionLabel={(option) =>
+                `${option.value} (${noFilterCounters.continents[option.value]})`
+              }
+              options={continentOptions}
+              onChange={(option) => {
+                setContinentFilter(option ? option.value : null);
+                setCountryFilter(null);
+              }}
+              value={
+                continentFilter
+                  ? continentOptions.filter((o) => o.value === continentFilter)
+                  : null
+              }
+            />
+          </div>
+          <div className={s.filter}>
+            <div className={s.filterLabel}>Filter by Country</div>
+
+            <ReactSelect
+              isClearable
+              formatOptionLabel={(option) =>
+                `${option.value} (${noFilterCounters.countries[option.value]})`
+              }
+              options={countryOptions}
+              onChange={(option) => {
+                setCountryFilter(option ? option.value : null);
+              }}
+              value={
+                countryFilter
+                  ? countryOptions.find((o) => o.value === countryFilter)
+                  : null
+              }
+            />
+          </div>
+          <div className={s.filter}>
+            <div className={s.filterLabel}>Filter by Technology</div>
+
+            <ReactSelect
+              isClearable
+              formatOptionLabel={(option) => option.value}
+              options={technologyOptions}
+              onChange={(option) => {
+                setTechnologyFilter(option ? option.value : null);
+              }}
+              value={
+                technologyFilter
+                  ? technologyOptions.find((o) => o.value === technologyFilter)
+                  : null
+              }
+            />
+          </div>
+          <div className={s.filter}>
+            <div className={s.filterLabel}>Filter by Area of expertise</div>
+
+            <ReactSelect
+              isClearable
+              formatOptionLabel={(option) => option.value}
+              options={areaOfExpertiseOptions}
+              onChange={(option) => {
+                setAreaOfExpertiseFilter(option ? option.value : null);
+              }}
+              value={
+                areaOfExpertiseFilter
+                  ? areaOfExpertiseOptions.find(
+                      (o) => o.value === areaOfExpertiseFilter,
+                    )
+                  : null
+              }
+            />
+          </div>
+        </div> */}
+
+        <div className={s.posts}>
+          {filtered.map((post, i) => (
+            <Link href={`/tech-partners/${post.slug}`} key={post.slug}>
+              <a
+                className={classNames(
+                  s.post,
+                  countBySlug[post.slug] && s.postWithShowcasedProjects,
+                )}
+              >
+                <div
+                  className={classNames(s.postLogo, styles[i % styles.length])}
+                >
+                  <img src={post.logo.url} />
+                </div>
+                <div className={s.postBody}>
+                  <div className={s.postTitle}>
+                    {post.name}{' '}
+                    {post.locations.slice(0, 5).map((l) => (
+                      <span key={l.emoji}>{l.emoji}</span>
+                    ))}
+                    {post.locations.length > 5 && (
+                      <span className={s.moreLocations}>
+                        {' + '}
+                        {post.locations.length - 5} more
+                      </span>
+                    )}
+                  </div>
+                  <div className={s.postDescription}>
+                    {toPlainText(post.shortDescription)}
+                  </div>
+                </div>
+              </a>
+            </Link>
+          ))}
+        </div>
+      </Wrapper>
+    </Layout>
+  );
+}

--- a/pages/tech-partners/index.jsx
+++ b/pages/tech-partners/index.jsx
@@ -12,7 +12,7 @@ import { uniq } from 'lodash-es';
 import sortBy from 'lodash-es/sortBy';
 import Link from 'next/link';
 import React, { useState } from 'react';
-import ReactSelect from 'react-select';
+// import ReactSelect from 'react-select';
 import { useQuerySubscription } from 'utils/useQuerySubscription';
 import s from './style.module.css';
 
@@ -170,32 +170,32 @@ export default function TechPartners({ subscription, preview }) {
     return true;
   });
 
-  const filteredCounters = calculateCounters(filtered, continentFilter);
-  const noFilterCounters = calculateCounters(ordered, continentFilter);
+  // const filteredCounters = calculateCounters(filtered, continentFilter);
+  // const noFilterCounters = calculateCounters(ordered, continentFilter);
 
-  const someFilters =
-    continentFilter ||
-    countryFilter ||
-    technologyFilter ||
-    areaOfExpertiseFilter;
+  // const someFilters =
+  //   continentFilter ||
+  //   countryFilter ||
+  //   technologyFilter ||
+  //   areaOfExpertiseFilter;
 
-  const continentOptions = Object.entries(filteredCounters.continents)
-    .sort(byCount)
-    .map(toOption);
+  // const continentOptions = Object.entries(filteredCounters.continents)
+  //   .sort(byCount)
+  //   .map(toOption);
 
-  const countryOptions = Object.entries(filteredCounters.countries)
-    .sort(byCount)
-    .map(toOption);
+  // const countryOptions = Object.entries(filteredCounters.countries)
+  //   .sort(byCount)
+  //   .map(toOption);
 
-  const technologyOptions = Object.entries(filteredCounters.technologies)
-    .sort(byCount)
-    .map(toOption);
+  // const technologyOptions = Object.entries(filteredCounters.technologies)
+  //   .sort(byCount)
+  //   .map(toOption);
 
-  const areaOfExpertiseOptions = Object.entries(
-    filteredCounters.areaOfExpertise,
-  )
-    .sort(byCount)
-    .map(toOption);
+  // const areaOfExpertiseOptions = Object.entries(
+  //   filteredCounters.areaOfExpertise,
+  // )
+  //   .sort(byCount)
+  //   .map(toOption);
 
   return (
     <Layout preview={preview}>

--- a/pages/tech-partners/style.module.css
+++ b/pages/tech-partners/style.module.css
@@ -1,6 +1,6 @@
 .posts {
   display: grid;
-  grid-gap: 40px;
+  gap: 40px;
   grid-template-columns: repeat(1, 1fr);
 
   @media (min-width: 600px) {
@@ -106,7 +106,7 @@
 
 .filterGrid {
   display: grid;
-  grid-gap: 30px;
+  gap: 30px;
   margin-bottom: 100px;
   margin-top: 80px;
   font-size: 16px;

--- a/pages/tech-partners/style.module.css
+++ b/pages/tech-partners/style.module.css
@@ -1,0 +1,128 @@
+.posts {
+  display: grid;
+  grid-gap: 40px;
+  grid-template-columns: repeat(1, 1fr);
+
+  @media (min-width: 600px) {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 1000px) {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.post {
+  text-decoration: none;
+  color: inherit;
+  box-shadow: var(--box-shadow);
+  border-radius: 10px;
+  overflow: hidden;
+  position: relative;
+  top: 0;
+  transition: top 0.2s ease-in-out;
+
+  &:hover {
+    top: -10px;
+  }
+}
+
+.postWithShowcasedProjects {
+  padding-bottom: 35px;
+}
+
+.postLogo {
+  padding: 40px rfs(70px);
+  text-align: center;
+  border-bottom: 1px solid var(--border-color);
+
+  img {
+    width: 100%;
+    height: 80px;
+  }
+}
+
+.postBody {
+  padding: 30px;
+}
+
+.postTitle {
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.moreLocations {
+  color: var(--light-body-color);
+  font-weight: normal;
+  font-size: 14px;
+}
+
+.postDescription {
+  font-size: 16px;
+  color: var(--light-body-color);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.pinkLogo {
+  background: linear-gradient(45deg, #f9ecfe, white);
+}
+
+.azureLogo {
+  background: linear-gradient(45deg, #e9fcff, white);
+}
+
+.grayLogo {
+  background: linear-gradient(45deg, #e9fcff, white);
+}
+
+.blueLogo {
+  background: linear-gradient(45deg, #e9e9ff, white);
+}
+
+.greenLogo {
+  background: linear-gradient(45deg, #e9ffed, white);
+}
+
+.yellowLogo {
+  background: linear-gradient(45deg, #feffe9, white);
+}
+
+.showcasedProjects {
+  background: var(--highlight-bg-color);
+  padding: 3px 5px;
+  display: inline-block;
+  font-size: 13px;
+  font-weight: bold;
+  position: absolute;
+  bottom: 30px;
+  left: 30px;
+  border-radius: 4px;
+}
+
+.filterGrid {
+  display: grid;
+  grid-gap: 30px;
+  margin-bottom: 100px;
+  margin-top: 80px;
+  font-size: 16px;
+
+  @media (min-width: 600px) {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 940px) {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.filterLabel {
+  color: var(--light-body-color);
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
This PR introduces a new /tech-partners cluster for SaaS/API partners that don't belong in the agency partner program (ex: Mux and imgix)

To-do
- [x] Introduce a /tech-partners index
- [x] Introduce a /tech-partners/slug page per partner 
- [x] Add /tech-partners to the footer

Notes for @marcomezzavilla:
- There's some known issues and conflicts when running `npm i` and using Node v20+, this PR is after downgrading to v16.20.2
- This PR has not updated packages as it leads to a `renderRule` error from react-datocms
- There's another conflict where updating packages leads to `react-datocms` being on 1.6.3, and updating manually to 6.0.1 leads to a `renderRule` conflict resolution, but breaks `/docs/community-tutorials` which @marcelofinamorvieira was looking into