### PR TITLE
Remove background color for code inside doc callout blocks

### DIFF
--- a/pages/docs/pageStyle.module.css
+++ b/pages/docs/pageStyle.module.css
@@ -490,6 +490,10 @@
   > *:last-child {
     margin-bottom: 0;
   }
+
+  code {
+    background-color: unset;
+  }
 }
 
 .docCallout--neutral,

--- a/pages/docs/pageStyle.module.css
+++ b/pages/docs/pageStyle.module.css
@@ -491,7 +491,7 @@
     margin-bottom: 0;
   }
 
-  code {
+  pre code {
     background-color: unset;
   }
 }


### PR DESCRIPTION
Simple fix.

## Before
Code blocks inside doc callouts had their own background color.

![Screenshot 000140](https://github.com/user-attachments/assets/13985a8e-ba45-4d4e-aa9a-2816aa8dad7c)

## After
Code blocks (`<pre><code>`) inside doc callouts use their parent's background color:
![Screenshot 000141](https://github.com/user-attachments/assets/e7985529-4185-4eb1-ad09-7ec79091e412)

Inline code (`<code> without <pre>`) is unaffected:
![Screenshot 000142](https://github.com/user-attachments/assets/c79fd01c-6fed-4c8a-bcc7-ad5cb27b1658)

