### PR TITLE
Provide TOC deep links to functions

### DIFF
--- a/components/DocPageContent/index.jsx
+++ b/components/DocPageContent/index.jsx
@@ -9,6 +9,8 @@ import FaceSmileBeamIcon from 'public/icons/regular/smile.svg';
 import WandMagicSparklesIcon from 'public/icons/regular/wand-magic.svg';
 import { Fragment } from 'react';
 import { StructuredText } from 'react-datocms';
+import Heading from "../Heading";
+import {FUNCTIONS_REFERENCE_ANCHOR_NAME} from "../../pages/docs/[...chunks]";
 
 export default function DocPageContent({ additionalData, ...props }) {
   return (
@@ -20,6 +22,7 @@ export default function DocPageContent({ additionalData, ...props }) {
             return (
               <>
                 <hr />
+                <Heading as="h3" anchor={FUNCTIONS_REFERENCE_ANCHOR_NAME}>Function Reference</Heading>
                 {additionalData.pluginSdkHooks
                   .sort((a, b) => a.lineNumber - b.lineNumber)
                   .map((hook) => (

--- a/components/Heading/index.jsx
+++ b/components/Heading/index.jsx
@@ -1,5 +1,13 @@
 import s from './style.module.css';
 
+
+/**
+ * Add a header. Specify an anchor name to provide an easy deep-link target.
+ * @param {string} props.as - Required: The tag to be rendered (e.g., 'h1', 'h2')
+ * @param {string} [props.anchor] - Optional: Used to create a permalink and an anchor within the heading
+ *
+ * @returns {JSX.Element}
+ */
 const Heading = ({ as: Tag, anchor, children, className, ...other }) => (
   <Tag
     {...other}

--- a/components/PluginSdkHook/index.jsx
+++ b/components/PluginSdkHook/index.jsx
@@ -130,8 +130,8 @@ export default function Hook({ hook }) {
 
   return (
     <div key={hook.name}>
-      <Heading anchor={hook.name} as="h3">
-        <code>{hook.name}</code>
+      <Heading anchor={hook.name} as="h4">
+        <code>{hook.name}()</code>
       </Heading>
       <Markdown>{hook.description}</Markdown>
       {hook.returnType && (

--- a/pages/docs/[...chunks].jsx
+++ b/pages/docs/[...chunks].jsx
@@ -533,7 +533,13 @@ export const Sidebar = ({ title, entries, techStarterKit }) => {
   );
 };
 
-export function Toc({ content, extraEntries: extra }) {
+/**
+ * For pages with plugin hooks, this is the name of the anchor link in the sidebar and in-page anchor.
+ * @type {string}
+ */
+export const FUNCTIONS_REFERENCE_ANCHOR_NAME = 'function-reference';
+
+export function Toc({ content, extraEntries: extra, pluginSdkHooks = [] }) {
   const nodes =
     content &&
     filter(content.value.document, isHeading).map((heading) => {
@@ -561,17 +567,36 @@ export function Toc({ content, extraEntries: extra }) {
           <div className={s.tocTitle}>In this page</div>
           <div className={s.entries}>
             {nodes.map((node) => (
-              <div className={s.tocEntry} key={node.url}>
-                <StructuredText data={node} />
-              </div>
+                <div className={s.tocEntry} key={node.url}>
+                  <StructuredText data={node}/>
+                </div>
             ))}
             {extraEntries}
+            {
+              // If a plugin page, also make TOC entries for each function
+              !!pluginSdkHooks?.length && <>
+              <br/>
+              <div className={s.tocTitle}>Function Reference</div>
+              <div className={s.tocEntry}>
+                {pluginSdkHooks.map((hook, key) => (
+                    <div className={s.tocEntry} key={key}>
+                      <a href={`#${hook.name}`} className={s.tocEntry}>
+                        <code>{
+                          // Add zero-width spaces to camelCase function names so they can wrap at word boundaries
+                          hook.name.replace(/([a-z])([A-Z])/g, "$1\u200B$2")
+                        }()</code>
+                      </a>
+                    </div>
+                ))}
+              </div>
+            </>
+            }
           </div>
         </div>
       </div>
     </div>
   ) : (
-    <div className={s.emptySidebar} />
+      <div className={s.emptySidebar}/>
   );
 }
 
@@ -642,18 +667,18 @@ export default function DocPage({
       <Head>{renderMetaTags(seo)}</Head>
       <div className={s.articleContainer}>
         {docGroup && docGroup.pages.length > 1 && (
-          <Toc content={page.content} />
+          <Toc content={page.content} pluginSdkHooks={additionalData?.pluginSdkHooks}/>
         )}
         <div className={s.article}>
           <h1 className={s.kicker}>{`${
-            docGroup && `${docGroup.name} > `
+              docGroup && `${docGroup.name} > `
           }${pageTitle}`}</h1>
           <div className={s.title}>{pageTitle}</div>
           <DocPageContent
-            additionalData={additionalData}
-            content={page.content}
-            style={s}
-            defaultAltForImages={defaultSeoTitle}
+              additionalData={additionalData}
+              content={page.content}
+              style={s}
+              defaultAltForImages={defaultSeoTitle}
           />
         </div>
       </div>


### PR DESCRIPTION
For Plugin SDK documentation pages, this adds TOC sidebar links to the functions at the bottom. Without these links, those sections are hard to notice.

## Before
![Screenshot 000166](https://github.com/user-attachments/assets/48b44a46-3fcc-4b3e-93cf-3354049cc3fa)

## After (this PR)
Pages with plugin functions:
![Screenshot 000167](https://github.com/user-attachments/assets/8ad9ca86-f1c2-4b9b-bc03-58dda4630aea)

Regular pages without plugins functions are unaffected:
![Screenshot 000169](https://github.com/user-attachments/assets/6cd2d6e8-919e-4717-b3a9-ae07c63f908b)
