### PR TITLE
Docs landing page reorganization + Better separation of official & community videos

### DIFF
--- a/pages/docs/community-tutorials/index.jsx
+++ b/pages/docs/community-tutorials/index.jsx
@@ -5,6 +5,7 @@ import { Sidebar } from 'pages/docs';
 import s from 'pages/docs/pageStyle.module.css';
 import { Image as DatoImage } from 'react-datocms';
 import t from './style.module.css';
+import Link from "next/link";
 
 export const getStaticProps = gqlStaticProps(
   /* GraphQL */
@@ -61,11 +62,15 @@ export default function Tutorials({ tutorials, roots }) {
   return (
     <DocsLayout sidebar={<Sidebar roots={roots} />}>
       <Head>
-        <title>Video Tutorials — DatoCMS</title>
+        <title>Community Video Tutorials — DatoCMS</title>
       </Head>
       <div className={s.articleContainer}>
         <div className={s.article}>
-          <div className={s.title}>Video Tutorials</div>
+          <div className={s.title}>DatoCMS Community Videos</div>
+
+          <p>New here? We recommend starting with our official <Link href="/user-guides">DatoCMS Editor Guides</Link>, which offer a series of videos and written tutorials to help you learn the basics.</p>
+
+          <p>The below are a collection of additional videos made by our awesome community members covering a wide range of topics, from beginner to advanced.</p>
 
           <div className={t.tutorials}>
             {tutorials.map((tutorial) =>

--- a/pages/docs/index.jsx
+++ b/pages/docs/index.jsx
@@ -3,12 +3,15 @@ import DocsLayout from 'components/DocsLayout';
 import Head from 'components/Head';
 import { gqlStaticProps, imageFields, seoMetaTagsFields } from 'lib/datocms';
 import Link from 'next/link';
-import Schema from 'public/images/illustrations/dynamic-layouts.svg';
-import GraphQl from 'public/images/illustrations/graphql-api.svg';
-import GettingStarted from 'public/images/illustrations/marketers.svg';
-import Next from 'public/images/logos/next.svg';
-import Nuxt from 'public/images/logos/nuxt.svg';
-import Svelte from 'public/images/logos/svelte.svg';
+import SchemaIcon from 'public/images/illustrations/dynamic-layouts.svg';
+import CDAIcon from 'public/images/illustrations/graphql-api.svg';
+import GettingStartedIcon from 'public/images/illustrations/marketers.svg';
+import VideoIcon from 'public/images/illustrations/video-encoding.svg'
+import HeadlessIcon from 'public/images/illustrations/developers-2.svg'
+import CMAIcon from 'public/images/illustrations/content-editors2.svg'
+import NextIcon from 'public/images/logos/next.svg';
+import NuxtIcon from 'public/images/logos/nuxt.svg';
+import SvelteIcon from 'public/images/logos/svelte.svg';
 import { Image as DatoImage, renderMetaTags } from 'react-datocms';
 import s from './style.module.css';
 
@@ -101,7 +104,7 @@ export const Sidebar = ({ roots }) => (
           href="/docs/community-tutorials"
           activeClassName={s.activePage}
         >
-          <a className={s.guide}>Video Tutorials</a>
+          <a className={s.guide}>Community Videos</a>
         </ActiveLink>
       </div>
     </div>
@@ -113,39 +116,69 @@ export default function Docs({ roots, preview, tutorials, tutsCount, page }) {
     <DocsLayout preview={preview} sidebar={<Sidebar roots={roots} />}>
       <Head>{renderMetaTags(page.seo)}</Head>
       <div className={s.container}>
-        <h2 className={s.title}>Documentation</h2>
+        <h2 className={s.title}>DatoCMS Documentation</h2>
         <p className={s.subtitle}>
           Whether you’re a startup or a global enterprise, learn how to
           integrate with DatoCMS to manage your content in a centralized,
           structured hub.
         </p>
 
-        <h6 className={s.introTitle}>Start with your use case</h6>
+        <h6 className={s.introTitle}>For everyone</h6>
         <div className={s.useCaseCards}>
           <Link href="/docs/general-concepts">
             <a className={s.useCaseCard}>
-              <GettingStarted />
-              <div className={s.useCaseCardTitle}>Getting started</div>
-              <p>Learn all the basic concepts and features behind DatoCMS.</p>
+              <GettingStartedIcon/>
+              <div className={s.useCaseCardTitle}>What is DatoCMS?</div>
+              <p>Learn the basic concepts and features of DatoCMS.</p>
             </a>
           </Link>
+
+          <Link href="/user-guides">
+            <a className={s.useCaseCard}>
+              <VideoIcon/>
+              <div className={s.useCaseCardTitle}>Videos & Tutorials</div>
+              <p>Jump right in with our video walkthroughs and step-by-step tutorials.</p>
+            </a>
+          </Link>
+
           <Link href="/docs/content-modelling">
             <a className={s.useCaseCard}>
-              <Schema />
-
-              <div className={s.useCaseCardTitle}>Model your schema</div>
+              <SchemaIcon/>
+              <div className={s.useCaseCardTitle}>Modeling your first schema</div>
               <p>
-                Build your administrative area and define the structure of your
-                content.
+               Structure your own content in our easy-to-use interface.
               </p>
             </a>
           </Link>
+
+
+        </div>
+
+        <h6 className={s.introTitle}>For developers</h6>
+        <div className={s.useCaseCards}>
+          <Link href="/academy">
+            <a className={s.useCaseCard}>
+              <HeadlessIcon/>
+              <div className={s.useCaseCardTitle}>What is a headless CMS?</div>
+              <p>
+                Join us for a gentle intro to modern web dev with headless CMSes and JS frontends.
+              </p>
+            </a>
+          </Link>
+
           <Link href="/docs/content-delivery-api">
             <a className={s.useCaseCard}>
-              <GraphQl />
+              <CDAIcon/>
+              <div className={s.useCaseCardTitle}>GraphQL API Reference</div>
+              <p>Fetch exactly what your frontend needs with our Content Delivery API.</p>
+            </a>
+          </Link>
 
-              <div className={s.useCaseCardTitle}>GraphQL API</div>
-              <p>Learn how to fetch your content into any frontend project.</p>
+          <Link href="/docs/content-management-api">
+            <a className={s.useCaseCard}>
+              <CMAIcon/>
+              <div className={s.useCaseCardTitle}>REST API Reference</div>
+              <p>Programmatically create and edit content with our Content Management API.</p>
             </a>
           </Link>
         </div>
@@ -154,61 +187,65 @@ export default function Docs({ roots, preview, tutorials, tutsCount, page }) {
         <div className={s.useCaseCards}>
           <Link href="/docs/next-js">
             <a className={s.useCaseCard}>
-              <Next />
-              <div className={s.useCaseCardTitle}>Next.js</div>
+              <NextIcon/>
+              <div className={s.useCaseCardTitle}>Next.js + DatoCMS</div>
               <p>Learn how to integrate your Next.js website with DatoCMS</p>
             </a>
           </Link>
           <Link href="/docs/nuxt">
             <a className={s.useCaseCard}>
-              <Nuxt />
-              <div className={s.useCaseCardTitle}>Nuxt</div>
+              <NuxtIcon/>
+              <div className={s.useCaseCardTitle}>Nuxt + DatoCMS</div>
               <p>Learn how to integrate your Nuxt website with DatoCMS</p>
             </a>
           </Link>
           <Link href="/docs/svelte">
             <a className={s.useCaseCard}>
-              <Svelte />
-              <div className={s.useCaseCardTitle}>Svelte</div>
+              <SvelteIcon/>
+              <div className={s.useCaseCardTitle}>Svelte + DatoCMS</div>
               <p>Learn how to integrate your Svelte website with DatoCMS</p>
             </a>
           </Link>
         </div>
 
         <h6 className={s.introTitle}>
-          <Link href="/docs/community-tutorials">
-            <a>Video Tutorials ({tutsCount.count})</a>
-          </Link>
+          Community Videos
         </h6>
+        <p>If you&apos;re new to DatoCMS, we recommend starting with our official <Link href="/user-guides">Editor Guides</Link>, which cover the basics in a series of videos and written tutorials.</p>
+        <p>Want more videos? Check out these awesome community contributions:</p>
         <div className={s.useCaseCards}>
           {tutorials.map((tutorial) =>
-            tutorial.res._modelApiKey === 'youtube_video_resource' ? (
-              <a
-                href={tutorial.res.video.url}
-                key={tutorial.res.video.url}
-                className={s.videoCard}
-              >
-                <div className={s.tutorialCover}>
-                  <img src={tutorial.res.video.thumbnailUrl} />
-                </div>
-                <div className={s.videoCardTitle}>{tutorial.title}</div>
-              </a>
-            ) : (
-              <a
-                href={tutorial.res.url}
-                key={tutorial.res.url}
-                className={s.videoCard}
-              >
-                <div className={s.videoCardCover}>
-                  {tutorial.res.coverImage && (
-                    <DatoImage data={tutorial.res.coverImage.responsiveImage} />
-                  )}
-                </div>
-                <div className={s.videoCardTitle}>{tutorial.title}</div>
-              </a>
-            ),
+              tutorial.res._modelApiKey === 'youtube_video_resource' ? (
+                  <a
+                      href={tutorial.res.video.url}
+                      key={tutorial.res.video.url}
+                      className={s.videoCard}
+                  >
+                    <div className={s.tutorialCover}>
+                      <img src={tutorial.res.video.thumbnailUrl}/>
+                    </div>
+                    <div className={s.videoCardTitle}>{tutorial.title}</div>
+                  </a>
+              ) : (
+                  <a
+                      href={tutorial.res.url}
+                      key={tutorial.res.url}
+                      className={s.videoCard}
+                  >
+                    <div className={s.videoCardCover}>
+                      {tutorial.res.coverImage && (
+                          <DatoImage data={tutorial.res.coverImage.responsiveImage}/>
+                      )}
+                    </div>
+                    <div className={s.videoCardTitle}>{tutorial.title}</div>
+                  </a>
+              ),
           )}
         </div>
+        <p><Link href="/docs/community-tutorials">
+          <a>See more videos ({tutsCount.count} total)</a>
+        </Link>
+        </p>
       </div>
     </DocsLayout>
   );


### PR DESCRIPTION
Reorganized the documentation landing page to better show content both for editors and developers.

## Before
![Screenshot 000200](https://github.com/user-attachments/assets/a13cc0b8-714f-403f-8277-addfe1eca1f4)

## After
![Screenshot 000201](https://github.com/user-attachments/assets/c91bb5ea-97e6-4efb-b16f-1e922c13cc91)

Also on the Community Videos page:
![Screenshot 000202](https://github.com/user-attachments/assets/78ddd57f-1655-44ac-b989-5e327a018d6d)
