### PR TITLE
Add code formatting to table headers & cells

### DIFF
--- a/components/PostContent/index.jsx
+++ b/components/PostContent/index.jsx
@@ -22,6 +22,7 @@ import ResponsiveEmbed from 'react-responsive-embed';
 import truncate from 'truncate';
 import slugify from 'utils/slugify';
 import partnerStyles from '/pages/partners/[partnerSlug]/style.module.css';
+import { backticksToHtmlCodeBlock } from '../../utils/backticksToHtmlCodeBlock';
 import { parseShortCodes } from '../../utils/table';
 import defaultStyles from './style.module.css';
 
@@ -363,18 +364,26 @@ function renderBlock(s, block, defaultAltForImages) {
             <thead>
               <tr>
                 {columns.map((col) => (
-                  <th key={col.id} style={toCss(col.style)}>
-                    {col.content}
-                  </th>
+                  <th
+                    key={col.id}
+                    style={toCss(col.style)}
+                    dangerouslySetInnerHTML={{
+                      __html: backticksToHtmlCodeBlock(col.content),
+                    }}
+                  />
                 ))}
               </tr>
             </thead>
             {block.table.data.map((row) => (
               <tr key={JSON.stringify(row)}>
                 {columns.map((col) => (
-                  <td key={col.id} style={toCss(col.style)}>
-                    {row[col.id]}
-                  </td>
+                  <td
+                    key={col.id}
+                    style={toCss(col.style)}
+                    dangerouslySetInnerHTML={{
+                      __html: backticksToHtmlCodeBlock(row[col.id]),
+                    }}
+                  />
                 ))}
               </tr>
             ))}

--- a/utils/backticksToHtmlCodeBlock.js
+++ b/utils/backticksToHtmlCodeBlock.js
@@ -1,0 +1,21 @@
+import { escape as escapeHtml } from 'lodash-es';
+
+/**
+ * Converts text wrapped in backticks within a string to HTML code blocks.
+ *
+ * Escapes HTML chars within the input string (using lodash's escape() func)
+ * then replaces instances of backtick-wrapped text with HTML `<code>` tags.
+ *
+ * In a React component, you'll have to use dangerouslySetInnerHTML to render this output.
+ *
+ * @param {string} input - The input string containing text with potential backtick-wrapped sections.
+ * @returns {string} - The input string with backtick-wrapped sections converted to `<code>` blocks.
+ */
+export const backticksToHtmlCodeBlock = (input) => {
+  const escapedInput = escapeHtml(input);
+  const backticksToCodeBlocks = escapedInput.replace(
+    /`([^`]+?)`/g,
+    '<code>$1</code>',
+  );
+  return backticksToCodeBlocks;
+};


### PR DESCRIPTION
I know we're trying to minimize changes to this repo pending a rewrite, but is this small tweak to table formatting ok? It just formats `` `backtick_formatted_code` `` into proper `<code>HTML code blocks</code>`.

Uses `dangerouslySetInnerHTML` with [lodash.escape()](https://lodash.com/docs/4.17.15#escape).

## Before
(From https://www.datocms.com/docs/plugin-sdk/field-extensions#reference-table-field-types--internal-names)

Backticks are literals:
![Screenshot 000588](https://github.com/user-attachments/assets/878d0a45-272a-4ef5-92c9-a6f243b720a2)

## After
Backticks are now properly code-blocked:
![Screenshot 000589](https://github.com/user-attachments/assets/e5b76d2b-f413-4379-bc18-f0246100b2db)

Other tables are still OK:
![Screenshot 000586](https://github.com/user-attachments/assets/7d603329-0f20-4243-92bc-d0a8cd88ef40)

![Screenshot 000587](https://github.com/user-attachments/assets/b6155508-f659-42f2-a06a-d1cf254cd0a7)

