### PR TITLE
Bugfix: Repo wasn't building because API key changed

### DIFF
--- a/lib/datocms.js
+++ b/lib/datocms.js
@@ -232,7 +232,7 @@ export const featureCardFields = /* GraphQL */ `
         ... on TemplateDemoRecord {
           code
         }
-        ... on UserGuidesVideoRecord {
+        ... on UserGuidesEpisodeRecord {
           parent: _allReferencingUserGuidesChapters {
             slug
           }

--- a/pages/blog/[slug]/index.jsx
+++ b/pages/blog/[slug]/index.jsx
@@ -71,7 +71,7 @@ export const getStaticProps = gqlStaticPropsWithSubscription(
                   id
                   _modelApiKey
                 }
-                ... on UserGuidesVideoRecord {
+                ... on UserGuidesEpisodeRecord {
                   title
                   slug
                   thumbTimeSeconds

--- a/pages/customer-stories/[slug]/index.jsx
+++ b/pages/customer-stories/[slug]/index.jsx
@@ -56,7 +56,7 @@ export const getStaticProps = gqlStaticPropsWithSubscription(
                   id
                   _modelApiKey
                 }
-                ... on UserGuidesVideoRecord {
+                ... on UserGuidesEpisodeRecord {
                   title
                   slug
                   thumbTimeSeconds

--- a/pages/docs/[...chunks].jsx
+++ b/pages/docs/[...chunks].jsx
@@ -330,7 +330,7 @@ export const getStaticProps = handleErrors(
                       id
                       _modelApiKey
                     }
-                    ... on UserGuidesVideoRecord {
+                    ... on UserGuidesEpisodeRecord {
                       title
                       slug
                       thumbTimeSeconds

--- a/pages/features/index.jsx
+++ b/pages/features/index.jsx
@@ -206,7 +206,7 @@ export const FeatureCard = ({ feature, index }) => {
           __typename: link.content.__typename,
           linkTitle: resolvedLinkTitle,
         };
-      case 'UserGuidesVideoRecord':
+      case 'UserGuidesEpisodeRecord':
         return {
           url: `/user-guides/${link.content.parent[0].slug}/${link.content.slug}`,
           __typename: link.content.__typename,

--- a/pages/user-guides/[...chunks]/index.jsx
+++ b/pages/user-guides/[...chunks]/index.jsx
@@ -40,7 +40,7 @@ export const getStaticPaths = gqlStaticPaths(
 export const getStaticProps = gqlStaticPropsWithSubscription(
   /* GraphQL */ `
     query itemQuery($chapterSlug: String!, $itemSlug: String!) {
-      item: userGuidesVideo(filter: { slug: { eq: $itemSlug } }) {
+      item: userGuidesEpisode(filter: { slug: { eq: $itemSlug } }) {
         slug
         seo: _seoMetaTags {
           ...seoMetaTagsFields


### PR DESCRIPTION
It seems like "User Guides Video" was changed to "User Guides Episode" in the CMS, and this broke the new-website repo.

Please merge this other fix first into this branch: https://github.com/datocms/new-website/pull/95